### PR TITLE
Add EventLog class

### DIFF
--- a/.skypilot/quick-release.yaml
+++ b/.skypilot/quick-release.yaml
@@ -8,7 +8,7 @@ bot:
 release:
   # access = 'public' or 'restricted'
   access: 'public'
-  publish: false
+  publish: true
 prerelease:
   access: 'public'
-  publish: false
+  publish: true

--- a/README.md
+++ b/README.md
@@ -10,3 +10,67 @@ A utility for flexibly tracking & displaying events
 ![next build](https://img.shields.io/github/workflow/status/skypilot-dev/logger/Prerelease?branch=next&label=next%20build)
 ![downloads](https://img.shields.io/npm/dm/@skypilot/logger)
 [![license: ISC](https://img.shields.io/badge/license-ISC-blue.svg)](https://opensource.org/licenses/ISC)
+
+## How to install
+
+```console
+yarn add @skypilot/logger
+```
+
+## How to use
+
+Add events:
+
+```typescript
+const log = new EventLog()
+log.debug('A debug event')
+log.info('An info event')
+log.warn('Something you should know')
+log.error('Uh-oh')
+```
+
+List event messages:
+
+```typescript
+log.getMessages()
+```
+
+```text
+Debug: A debug event
+Info: An info event
+Warn: Something you should know
+Error: Uh-oh
+```
+
+List one level of messages:
+
+```typescript
+log.getMessages('error')
+```
+
+```text
+Error: Uh-oh
+```
+
+Or access the messages directly:
+
+```typescript
+console.log(log.messages.error)
+```
+```text
+Uh-oh
+```
+
+Check for errors:
+
+```typescript
+console.log(log.hasErrors)
+```
+
+```text
+true
+```
+
+---
+
+More to be added

--- a/README.md
+++ b/README.md
@@ -71,6 +71,24 @@ console.log(log.hasErrors)
 true
 ```
 
+Add data to every event:
+
+```typescript
+const log = new EventLog({ initialData: { key: 'Always added' } })
+log.info('Event with data', { newKey: 'Added for one event' })
+log.getEvents()
+```
+
+```json
+[
+  {
+    "level": "info",
+    "message": "Event with data",
+    "data": { "key": "Always added", "newKey":  "Added for one event" }
+  }
+]
+```
+
 ---
 
 More to be added

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "tracing"
   ],
   "devDependencies": {
-    "@skypilot/toolchain": "^5.2.4-next.6"
+    "@skypilot/toolchain": "^5.2.4-next.6",
+    "type-fest": "^1.2.1"
   },
   "publishConfig": {
     "access": "restricted"

--- a/src/EventLog/EventLog.ts
+++ b/src/EventLog/EventLog.ts
@@ -15,17 +15,17 @@ export type EchoLevel = LogLevel | 'off';
 export type EchoDetail = 'message' | 'event';
 
 export interface Event<TData = any> {
-  id?: Integer | string;
   data?: TData;
+  id?: Integer | string;
   indentLevel?: Integer;
   level: LogLevel;
   message: string;
 }
 
-export interface LoggerOptions {
+export interface EventLogOptions {
+  baseIndentLevel?: Integer;
   echoDetail?: EchoDetail;
   echoLevel?: EchoLevel;
-  baseIndentLevel?: Integer;
   logLevel?: LogLevel;
   type?: string; // default type to assign to new events
 }
@@ -57,7 +57,7 @@ export class EventLog {
 
   private _events: Event[] = [];
 
-  constructor(options: LoggerOptions = {}) {
+  constructor(options: EventLogOptions = {}) {
     const { baseIndentLevel = 0, echoLevel = 'off', echoDetail = 'message', type } = options;
 
     this.baseIndentLevel = baseIndentLevel;
@@ -80,11 +80,11 @@ export class EventLog {
    * @description Merge multiple `EventLog` objects into one
    */
   static merge(eventLogs: EventLog[]): EventLog {
-    const mergedLogger = new EventLog();
+    const mergedEventLog = new EventLog();
     eventLogs.forEach(eventLog => {
-      mergedLogger.addEvents(eventLog.getEvents());
+      mergedEventLog.addEvents(eventLog.getEvents());
     });
-    return mergedLogger;
+    return mergedEventLog;
   }
 
   // Return a positive number if a > b; a negative number if a < b, or a 0 if they are equal. Higher = more severe

--- a/src/EventLog/EventLog.ts
+++ b/src/EventLog/EventLog.ts
@@ -1,0 +1,344 @@
+import type { ConditionalExcept } from 'type-fest';
+
+type Integer = number;
+
+export interface AddEventOptions<TData = any> {
+  id?: Integer | string;
+  data?: TData;
+  echoLevel?: EchoLevel;
+  indentLevel?: Integer;
+  type?: string;
+}
+
+export type EchoLevel = LogLevel | 'off';
+
+export type EchoDetail = 'message' | 'event';
+
+export interface Event<TData = any> {
+  id?: Integer | string;
+  data?: TData;
+  indentLevel?: Integer;
+  level: LogLevel;
+  message: string;
+}
+
+export interface LoggerOptions {
+  echoDetail?: EchoDetail;
+  echoLevel?: EchoLevel;
+  baseIndentLevel?: Integer;
+  logLevel?: LogLevel;
+  type?: string; // default type to assign to new events
+}
+
+export interface EventMessageOptions {
+  omitLevel?: boolean; // if true, don't prepend the level to the message
+}
+
+export interface FilterEventsParams {
+  maxLevel?: LogLevel;
+  minLevel?: LogLevel;
+}
+
+export type LogLevel = typeof EventLog.logLevels[number];
+
+export class EventLog {
+  static readonly logLevels = [
+    'debug',
+    'info',
+    'warn',
+    'error',
+  ] as const;
+
+  baseIndentLevel: Integer;
+  defaultType?: string;
+  echoDetail: 'message' | 'event';
+  echoLevel: EchoLevel;
+  indentLevel: Integer | undefined = undefined;
+
+  private _events: Event[] = [];
+
+  constructor(options: LoggerOptions = {}) {
+    const { baseIndentLevel = 0, echoLevel = 'off', echoDetail = 'message', type } = options;
+
+    this.baseIndentLevel = baseIndentLevel;
+    this.echoDetail = echoDetail;
+    this.echoLevel = echoLevel;
+
+    if (isDefined(type)) {
+      this.defaultType = type;
+    }
+  }
+
+  static meetsThreshold(logLevel: LogLevel | undefined, threshold: EchoLevel | undefined): boolean {
+    if (isUndefined(logLevel) || isUndefined(threshold) || threshold === 'off') {
+      return false;
+    }
+    return this.compareLevels(logLevel, threshold) >= 0;
+  }
+
+  /**
+   * @description Merge multiple `EventLog` objects into one
+   */
+  static merge(eventLogs: EventLog[]): EventLog {
+    const mergedLogger = new EventLog();
+    eventLogs.forEach(eventLog => {
+      mergedLogger.addEvents(eventLog.getEvents());
+    });
+    return mergedLogger;
+  }
+
+  // Return a positive number if a > b; a negative number if a < b, or a 0 if they are equal. Higher = more severe
+  private static compareLevels(a: LogLevel, b: LogLevel): Integer {
+    if (isUndefined(a)) {
+      return -1;
+    }
+
+    if (a === b) {
+      return 0;
+    }
+
+    return EventLog.logLevels.indexOf(a) - EventLog.logLevels.indexOf(b);
+  }
+
+  private static formatEventMessage(event: Event): string {
+    return `${capitalizeFirstWord(event.level)}: ${event.message}`;
+  }
+
+  private static formatEvent(event: Event): string {
+    function formatEntry(key: string, value: any, indentLevel = event.indentLevel || 0): string | string[] {
+      if (isUndefined(value)) {
+        return '';
+      }
+      if (isPlainObject(value)) {
+        return [
+          EventLog.indent(`${key}:`, indentLevel + 1),
+          ...Object.entries(value).map(
+            ([key, value]) => formatEntry(key, value, indentLevel + 1)
+          ).flat(),
+        ];
+      }
+      return EventLog.indent(
+        `${key}: ${JSON.stringify(value)}`, indentLevel + 1
+      );
+    }
+    return [
+      EventLog.indent(this.formatEventMessage(event), event.indentLevel),
+      formatEntry('id', event.id),
+      formatEntry('data', event.data),
+    ].flat().filter(Boolean).join('\n');
+  }
+
+  private static indent(text: string, indentLevel: Integer | undefined = 0): string {
+    return ['  '.repeat(indentLevel || 0), text].join('');
+  }
+
+  get counts(): Record<LogLevel, Integer> {
+    return {
+      debug: this.count('debug'),
+      info: this.count('info'),
+      warn: this.count('warn'),
+      error: this.count('error'),
+    };
+  }
+
+  get events(): Record<LogLevel, Event[]> {
+    return {
+      error: this.getEvents('error'),
+      warn: this.getEvents('warn'),
+      info: this.getEvents('info'),
+      debug: this.getEvents('debug'),
+    };
+  }
+
+  get hasEvents(): boolean {
+    return this._events.length > 0;
+  }
+
+  get highestLevel(): LogLevel | undefined {
+    if (!this._events.length) {
+      return undefined;
+    }
+
+    return this._events
+      .sort((a, b) => EventLog.compareLevels(a.level, b.level))
+      .reverse()[0].level;
+  }
+
+  get messages(): Record<Exclude<LogLevel, 'off'>, string[]> {
+    return {
+      error: this.getMessages('error', { omitLevel: true }),
+      warn: this.getMessages('warn', { omitLevel: true }),
+      info: this.getMessages('info', { omitLevel: true }),
+      debug: this.getMessages('debug', { omitLevel: true }),
+    };
+  }
+
+  get ok(): boolean {
+    const { highestLevel } = this;
+    return highestLevel === undefined || (EventLog.compareLevels(highestLevel, 'error') < 0);
+  }
+
+  addEvent<TData>(level: LogLevel, message: string, options: AddEventOptions<TData> = {}): Event {
+    const { id, data, echoLevel = this.echoLevel, indentLevel = this.indentLevel, type = this.defaultType } = options;
+
+    const event = {
+      ...(
+        isDefined(indentLevel) || this.baseIndentLevel
+          ? { indentLevel: (indentLevel || 0) + this.baseIndentLevel }
+          : {}
+      ),
+      level,
+      message,
+      ...omitUndefined({ id, data, type }),
+    };
+    this._events.push(event);
+
+    if (EventLog.meetsThreshold(level, echoLevel)) {
+      if (this.echoDetail === 'event') {
+        console[level](EventLog.formatEvent(event)); // TODO: Improve formatting; also allow a custom formatter
+      } else {
+        console[level](EventLog.formatEventMessage(event));
+      }
+    }
+
+    return event;
+  }
+
+  /**
+   * @description Append the events from one or more `EventLog` instances to this one and return this one
+   */
+  append(...eventLogs: EventLog[]): EventLog {
+    eventLogs.forEach(eventLog => {
+      eventLog.getEvents().forEach(event => {
+        const { level, message, ...options } = event;
+        // Echo only if the message is below the eventLog's threshold but at or above this log's threshold
+        const echoLevel = this.echoDetail === 'event' && eventLog.echoDetail === 'message' || (
+          !EventLog.meetsThreshold(level, eventLog.echoLevel)
+          && EventLog.meetsThreshold(level, this.echoLevel)
+        ) ? this.echoLevel : 'off';
+        this.addEvent(level, message, { ...options, echoLevel });
+      });
+    });
+    return this;
+  }
+
+  count(logLevel?: LogLevel): Integer {
+    return (
+      isUndefined(logLevel) ? this._events : this.getEvents(logLevel)
+    ).length;
+  }
+
+
+  debug<TData>(message: string, options: AddEventOptions<TData> = {}): EventLog {
+    this.addEvent('debug', message, options);
+    return this;
+  }
+
+  error<TData>(message: string, options: AddEventOptions<TData> = {}): EventLog {
+    this.addEvent('error', message, options);
+    return this;
+  }
+
+  filterEvents(params: FilterEventsParams): Event[] {
+    const { minLevel, maxLevel } = params;
+
+    return this._events.filter(event => (
+      (
+        isUndefined(minLevel)
+        || EventLog.logLevels.indexOf(event.level) >= EventLog.logLevels.indexOf(minLevel)
+      ) && (
+        isUndefined(maxLevel)
+        || EventLog.logLevels.indexOf(event.level) <= EventLog.logLevels.indexOf(maxLevel))
+    ));
+  }
+
+  filterMessages(params: FilterEventsParams, options: EventMessageOptions = {}): string[] {
+    const { omitLevel = false } = options;
+    return this.filterEvents(params)
+      .map(event => omitLevel ? event.message : EventLog.formatEventMessage(event));
+  }
+
+  getEvents<TData>(): Array<Event<TData>>;
+  getEvents<TData, L extends LogLevel>(level: L): Array<Event<TData> & { level: L }>;
+  /* eslint-disable @typescript-eslint/explicit-function-return-type */
+  /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+  getEvents(level?: LogLevel | undefined) {
+    if (level === undefined) {
+      return this._events;
+    }
+    return this._events.filter(message => message.level === level);
+  }
+
+  getMessages(level?: LogLevel, options: EventMessageOptions = {}): string[] {
+    const {  omitLevel = false } = options;
+    return (level === undefined ? this.getEvents() : this.getEvents(level))
+      .map(event => omitLevel ? event.message : EventLog.formatEventMessage(event));
+  }
+
+  has(level?: LogLevel | undefined): boolean {
+    return this.count(level) > 0;
+  }
+
+  info<TData>(message: string, options: AddEventOptions<TData> = {}): EventLog {
+    this.addEvent<TData>('info', message, options);
+    return this;
+  }
+
+  warn<TData>(message: string, options: AddEventOptions<TData> = {}): EventLog {
+    this.addEvent('warn', message, options);
+    return this;
+  }
+
+  private addEvents(events: Event[]): void {
+    this._events.push(...events);
+  }
+}
+
+
+/**
+ * @description Capitalize the first word of the string return the new string
+ */
+
+type PlainObject = { [key: string]: unknown } & ({ bind?: never } | { call?: never });
+
+function capitalizeFirstWord(str: string): string {
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}
+
+/**
+ * @description Return true if the value is not `undefined`
+ */
+function isDefined<T>(value: T | undefined): value is T {
+  return !isUndefined(value);
+}
+
+/**
+ * @description Return true if the value is a "plain" object: an object that is not a function, array, or null
+ */
+function isPlainObject(value: PlainObject | unknown): value is PlainObject {
+  return value instanceof Object && Object.getPrototypeOf(value) === Object.prototype;
+}
+
+/**
+ * @description Return true if the value is `undefined`
+ */
+function isUndefined<T>(value: T | undefined): value is undefined {
+  return typeof value === 'undefined';
+}
+
+/**
+ * @description Return a copy of the object, omitting keys whose values are undefined
+ */
+/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+function omitUndefined<O extends { [key: string]: any }>(obj: O): ConditionalExcept<O, undefined> {
+  return Object.entries(obj).reduce((acc, entry) => {
+    const [key, value] = entry;
+    if (isUndefined(value)) {
+      return acc;
+    }
+    return {
+      ...acc,
+      [key]: value,
+    };
+  }, {} as ConditionalExcept<O, undefined>);
+}

--- a/src/EventLog/__tests__/EventLog.unit.test.ts
+++ b/src/EventLog/__tests__/EventLog.unit.test.ts
@@ -1,0 +1,468 @@
+import { EventLog } from '../EventLog';
+
+describe('EventLog()', () => {
+  describe('static meetsThreshold(a: LogLevel | undefined, b: EchoLevel | undefined)', () => {
+    it('should return false if level a < level b', () => {
+      expect(
+        EventLog.meetsThreshold('warn', 'error')
+      ).toBe(false);
+    });
+
+    it('should return true if level a >= level b', () => {
+      expect(
+        EventLog.meetsThreshold('info', 'debug')
+      ).toBe(true);
+    });
+
+    it("no value should meet the threshold of 'off'", () => {
+      expect(
+        EventLog.meetsThreshold('error', undefined)
+      ).toBe(false);
+    });
+
+    it('an undefined logLevel should never meet a threshold', () => {
+      expect(
+        // Doesn't meet the lowest threshold
+        EventLog.meetsThreshold(undefined, 'debug')
+      ).toBe(false);
+      expect(
+        // Doesn't meet the threshold of 'off'
+        EventLog.meetsThreshold(undefined, 'off')
+      ).toBe(false);
+    });
+  });
+
+  describe('static merge(:EventLog)', () => {
+    it('should return a new EventLog containing all events from the EventLog instances in the array', () => {
+      const eventLog1 = new EventLog({ echoLevel: 'debug', echoDetail: 'event' })
+        .info('First', { id: 'any', data: { key: 'sample data', array: [1, 2], nested: { a: 1, b: 2 } } })
+        .warn('Second');
+      const eventLog2 = new EventLog()
+        .warn('Last');
+      const expectedMessages = [
+        'Info: First',
+        'Warn: Second',
+        'Warn: Last',
+      ];
+
+      const mergedEventLog = EventLog.merge([eventLog1, eventLog2]);
+      expect(mergedEventLog.getMessages()).toStrictEqual(expectedMessages);
+    });
+  });
+
+  describe('get events.error', () => {
+    it("should be an alias for getEvents('error')", () => {
+      const eventLog = new EventLog();
+      eventLog.error('Error event');
+      const expectedMessages = eventLog.getEvents('error');
+
+      const actualMessages = eventLog.events.error;
+      expect(actualMessages).toStrictEqual(expectedMessages);
+    });
+  });
+
+  describe('get messages', () => {
+    it('should return a dictionary of messages of all levels', () => {
+      // Example of method chaining
+      const eventLog = new EventLog()
+        .error('Error 1')
+        .warn('Warning')
+        .error('Error 2');
+
+      expect(eventLog.messages.error).toStrictEqual([
+        'Error 1',
+        'Error 2',
+      ]);
+      expect(eventLog.messages.warn).toStrictEqual([
+        'Warning',
+      ]);
+    });
+
+    it('if there are no messages, should return an empty array', () => {
+      const eventLog = new EventLog();
+      expect(eventLog.messages.error).toStrictEqual([]);
+      expect(eventLog.messages.warn).toStrictEqual([]);
+      expect(eventLog.messages.info).toStrictEqual([]);
+      expect(eventLog.messages.debug).toStrictEqual([]);
+    });
+  });
+
+  describe('addEvent()', () => {
+    it('should add the event to the EventLog', () => {
+      const eventLog = new EventLog();
+      expect(eventLog.count()).toBe(0);
+      expect(eventLog.hasEvents).toBe(false);
+
+      eventLog.addEvent('error', 'An error occurred');
+
+      expect(eventLog.count()).toBe(1);
+      expect(eventLog.hasEvents).toBe(true);
+      expect(eventLog.events.error).toHaveLength(1);
+      expect(eventLog.events.error[0]).toMatchObject({
+        level: 'error',
+        message: 'An error occurred',
+      });
+    });
+
+    it('should use a type option passed to the constructor', () => {
+      const eventLog = new EventLog({ type: 'validation' })
+        .error('Message');
+      const expectedEvent = { message: 'Message', type: 'validation' };
+
+      const actualEvents = eventLog.getEvents();
+      expect(actualEvents).toHaveLength(1);
+      expect(actualEvents[0]).toMatchObject(expectedEvent);
+    });
+
+    it('given a type option, should override the default type passed to the constructor', () => {
+      const eventLog = new EventLog({ type: 'validation' })
+        .error('Message', { type: 'not validation' });
+      const expectedEvent = { message: 'Message', type: 'not validation' };
+
+      const actualEvents = eventLog.getEvents();
+      expect(actualEvents).toHaveLength(1);
+      expect(actualEvents[0]).toMatchObject(expectedEvent);
+    });
+
+    it('indentLevel for an event should default to the value set on the EventLog instance', () => {
+      const eventLog = new EventLog();
+      eventLog.addEvent('info', 'no indentLevel');
+      eventLog.indentLevel = 1;
+      eventLog.warn('has indentLevel');
+      const expectedEvents = [
+        {
+          level: 'info',
+          message: 'no indentLevel',
+        },
+        {
+          indentLevel: 1,
+          level: 'warn',
+          message: 'has indentLevel',
+        },
+      ];
+
+      const actualEvents = eventLog.getEvents();
+      expect(actualEvents).toStrictEqual(expectedEvents);
+    });
+
+    it('if indentLevel is not set, should not add it to the event', () => {
+      const eventLog = new EventLog();
+      eventLog.addEvent('info', 'no indentLevel');
+      const expectedEvent = {
+        level: 'info',
+        message: 'no indentLevel',
+      };
+
+      const actualEvents = eventLog.getEvents();
+      expect(actualEvents).toHaveLength(1);
+      expect(actualEvents[0]).toStrictEqual(expectedEvent);
+    });
+
+    it('if indentLevel is set, should add it to the event', () => {
+      const eventLog = new EventLog();
+      eventLog.addEvent('info', 'has indentLevel', { indentLevel: 0 });
+      eventLog.error('has indentLevel', { indentLevel: 1 });
+      const expectedEvents = [
+        {
+          indentLevel: 0,
+          level: 'info',
+          message: 'has indentLevel',
+        },
+        {
+          indentLevel: 1,
+          level: 'error',
+          message: 'has indentLevel',
+        },
+      ];
+
+      const actualEvents = eventLog.getEvents();
+      expect(actualEvents).toStrictEqual(expectedEvents);
+    });
+  });
+
+  it('if baseIndentLevel is set to anything but 0, should add it to the event', () => {
+    const eventLog = new EventLog({ baseIndentLevel: 1 });
+    eventLog.info('baseIndentLevel');
+    const expectedEvent = {
+      indentLevel: 1,
+      level: 'info',
+      message: 'baseIndentLevel',
+    };
+
+    const actualEvents = eventLog.getEvents();
+    expect(actualEvents).toHaveLength(1);
+    expect(actualEvents[0]).toStrictEqual(expectedEvent);
+  });
+
+  it('if both indentLevel and baseIndentLevel are set, should add their sum to the event', () => {
+    const eventLog = new EventLog({ baseIndentLevel: 1 });
+    eventLog.info('baseIndentLevel+indentLevel', { indentLevel: 1 });
+    const expectedEvent = {
+      indentLevel: 2,
+      level: 'info',
+      message: 'baseIndentLevel+indentLevel',
+    };
+
+    const actualEvents = eventLog.getEvents();
+    expect(actualEvents).toHaveLength(1);
+    expect(actualEvents[0]).toStrictEqual(expectedEvent);
+  });
+
+  describe('append(...eventLogs: EventLog[])', () => {
+    it('should return a new EventLog containing all events from the EventLog arguments', () => {
+      const addendumLog = new EventLog({ echoLevel: 'error' })
+        .error('Second')
+        .warn('Third');
+      const expectedMessages = [
+        'Warn: First',
+        'Error: Second',
+        'Warn: Third',
+        'Error: Last',
+      ];
+
+      const baseLog = new EventLog({ echoLevel: 'warn' })
+        .warn('First')
+        .append(addendumLog)
+        .error('Last');
+      const actualMessages = baseLog.getMessages();
+
+      expect(actualMessages).toStrictEqual(expectedMessages);
+    });
+  });
+
+  describe('count(?:LogLevel)', () => {
+    it('should return the number of events in the log', () => {
+      const eventLog = new EventLog()
+        .info('info 1')
+        .debug('debug')
+        .info('info 2')
+        .warn('warn');
+      expect(eventLog.count()).toBe(4);
+      expect(eventLog.count('debug')).toBe(1);
+      expect(eventLog.count('info')).toBe(2);
+      expect(eventLog.count('warn')).toBe(1);
+      expect(eventLog.count('error')).toBe(0);
+    });
+  });
+
+  describe('get counts', () => {
+    it('should return an object containing counts for each log level', () => {
+      const eventLog = new EventLog()
+        .info('info 1')
+        .debug('debug')
+        .info('info 2')
+        .warn('warn');
+      const expected = {
+        debug: 1,
+        info: 2,
+        warn: 1,
+        error: 0,
+      };
+
+      const actual = eventLog.counts;
+      expect(actual).toStrictEqual(expected);
+    });
+  });
+
+  describe('debug(), error(), info() & warn()', () => {
+    it('should be a shorthand for addEvent() but return the instance to allow chaining', () => {
+      const eventLog = new EventLog()
+        .debug('Chained debug')
+        .error('Chained error')
+        .info('Chained info')
+        .warn('Chained warning');
+      const expectedMessages = [
+        'Debug: Chained debug',
+        'Error: Chained error',
+        'Info: Chained info',
+        'Warn: Chained warning',
+      ];
+
+      const actualMessages = eventLog.getMessages();
+      expect(actualMessages).toStrictEqual(expectedMessages);
+      expect(eventLog.count()).toBe(4);
+      expect(eventLog.hasEvents).toBe(true);
+    });
+  });
+
+  describe('filterEvents({ minLevel: LogLevel, maxLevel: LogLevel, omitLevel: boolean )', () => {
+    it('should return the events meeting the constraints', () => {
+      const eventLog = new EventLog();
+      eventLog.debug('Debug event');
+      eventLog.info('Info event');
+      eventLog.warn('Warn event');
+      eventLog.error('Error event');
+
+      const sets = [
+        {
+          params: { minLevel: 'warn' } as const,
+          expectedMessages : ['Warn event', 'Error event'],
+        },
+        {
+          params: { minLevel: 'debug', maxLevel: 'info' } as const,
+          expectedMessages : ['Debug event', 'Info event'],
+        },
+        {
+          params: { maxLevel: 'debug' } as const,
+          expectedMessages : ['Debug event'],
+        },
+      ];
+      sets.forEach(( { params, expectedMessages }) => {
+        expect(eventLog.filterEvents(params).map(
+          event => event.message
+        )).toStrictEqual(expectedMessages);
+        expect(
+          eventLog.filterMessages(params, { omitLevel: true })
+        ).toStrictEqual(expectedMessages);
+      });
+    });
+  });
+
+  describe('getEvents()', () => {
+    it('should return all events', () => {
+      interface Data { key: string }
+      expect.assertions(2);
+
+      const eventLog = new EventLog();
+      eventLog.info<Data>( 'Info event', { data: { key: 'typed value' } });
+      eventLog.debug('Debug event');
+
+
+      const [firstEvent] = eventLog.getEvents<Data>();
+      if (firstEvent) {
+        const { key } = firstEvent.data || {};
+        expect(key).toBe('typed value');
+      }
+
+      expect(eventLog.getEvents()).toHaveLength(2);
+    });
+
+    it('if logLevel is given, should return events only of that level', () => {
+      const eventLog = new EventLog();
+      eventLog.info('Info event');
+      eventLog.debug('Debug event');
+
+      expect(eventLog.getEvents('debug')).toHaveLength(1);
+    });
+  });
+
+  describe('getMessages()', () => {
+    it('should return the messages from the events', () => {
+      const eventLog = new EventLog();
+      eventLog.debug('Debug event');
+      eventLog.error('Error event');
+      eventLog.info('Info event');
+      eventLog.warn('Warn event');
+
+      expect(eventLog.getMessages()).toStrictEqual([
+        'Debug: Debug event',
+        'Error: Error event',
+        'Info: Info event',
+        'Warn: Warn event',
+      ]);
+    });
+
+    it('if there are no messages, should return an empty array', () => {
+      const eventLog = new EventLog();
+      expect(eventLog.getMessages()).toStrictEqual([]);
+    });
+
+    it('if logLevel is given, should return messages only of that level', () => {
+      const eventLog = new EventLog();
+      eventLog.warn('Warn event');
+      eventLog.error('Error event');
+
+      expect(eventLog.getMessages('error')).toStrictEqual([
+        'Error: Error event',
+      ]);
+    });
+  });
+
+  describe('has(:LogLevel)', () => {
+    it('should return true if there are any events', () => {
+      const eventLog = new EventLog();
+      eventLog.info('Info event');
+      expect(eventLog.has()).toBe(true);
+    });
+
+    it('should return false if there are no events', () => {
+      const eventLog = new EventLog();
+      expect(eventLog.has()).toBe(false);
+    });
+
+    it('if logLevel is given, should ignore events having a different level', () => {
+      const eventLog = new EventLog();
+      eventLog.info('Info event');
+
+      expect(eventLog.has()).toBe(true);
+      expect(eventLog.has('info')).toBe(true);
+      expect(eventLog.has('error')).toBe(false);
+    });
+  });
+
+  describe('has(:LogLevel)', () => {
+    it('if there are no events, should return false', () => {
+      expect(new EventLog().has()).toBe(false);
+    });
+
+    it('if logLevel is given, should return false if there are no events of that level', () => {
+      const eventLog = new EventLog();
+      eventLog.info('Info event');
+
+      expect(eventLog.has('info')).toBe(true);
+      const absentLogLevels = ['debug', 'error', 'warn'] as const;
+      absentLogLevels.forEach(level => {
+        expect(eventLog.has(level)).toBe(false);
+      });
+    });
+
+    it('if logLevel is given, should return true if there are any events of that level', () => {
+      const eventLog = new EventLog();
+      eventLog.info('Info event');
+      eventLog.warn('Warn event');
+
+      expect(eventLog.has('error')).toBe(false);
+    });
+  });
+
+  describe('highestLevel', () => {
+    it('should return the highest level among all events', () => {
+      const eventLog = new EventLog();
+
+      eventLog.info('Info event');
+      eventLog.warn('Warn event');
+      eventLog.debug('Debug event');
+
+      expect(eventLog.highestLevel).toBe('warn');
+    });
+
+    it('if there are no events, should return undefined', () => {
+      const eventLog = new EventLog();
+
+      expect(eventLog.highestLevel).toBeUndefined();
+    });
+  });
+
+  describe('ok', () => {
+    it('should return true if no messages were added', () => {
+      const eventLog = new EventLog();
+      expect(eventLog.ok).toBe(true);
+    });
+
+    it('should return true if no errors occurred', () => {
+      const eventLog = new EventLog()
+        .debug('Debug event')
+        .info('Info event')
+        .warn('Warn event');
+
+      expect(eventLog.ok).toBe(true);
+    });
+
+    it('should return false if any errors occurred', () => {
+      const eventLog = new EventLog()
+        .error('Error event');
+
+      expect(eventLog.ok).toBe(false);
+    });
+  });
+});

--- a/src/__tests__/validate-exports.app.test.ts
+++ b/src/__tests__/validate-exports.app.test.ts
@@ -1,0 +1,23 @@
+import * as actualExports from '../index';
+
+const intendedExports = [
+  'EventLog',
+];
+
+describe('Export validation', () => {
+
+  const actualExportNames = Object.keys(actualExports);
+
+  it('exports should include all intended exports', () => {
+    for (const exportName of intendedExports) {
+      expect(actualExportNames).toContain(exportName);
+    }
+  });
+
+
+  it('exports should not include any unintended exports', () => {
+    for (const exportName of actualExportNames) {
+      expect(intendedExports).toContain(exportName);
+    }
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export {};
+export * from './EventLog/EventLog';

--- a/yarn.lock
+++ b/yarn.lock
@@ -5444,6 +5444,11 @@ type-fest@^0.8.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
+type-fest@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-1.2.1.tgz#232990aa513f3f5223abf54363975dfe3a121a2e"
+  integrity sha512-SbmIRuXhJs8KTneu77Ecylt9zuqL683tuiLYpTRil4H++eIhqCmx6ko6KAFem9dty8sOdnEiX7j4K1nRE628fQ==
+
 typedarray-to-buffer@^3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"


### PR DESCRIPTION
## Features

- Migrated the `EventLogger` class from `@skypilot/sugarbowl`
- Initial data can now be set through the `initialData` option accepted by the `EventLogger` constructor